### PR TITLE
Fix a11y warnings

### DIFF
--- a/src/lib/speakers/Speakers.svelte
+++ b/src/lib/speakers/Speakers.svelte
@@ -176,41 +176,44 @@
 	<hr />
 	<ul class="grid">
 		{#each talks as {author, title, text}}
-			<li class="speaker" role="article">
-				<div class="profile">
-					{#each author as {image}}
-						<img src={image} alt="" />
-					{/each}
-				</div>
-				<div class="title">
-					{#each author as speaker}
-						<address rel="author">{speaker.name}
-							{#if speaker.twitter}
-								<a
-								href="https://twitter.com/{speaker.twitter}"
-								target="_blank"
-								rel="noopener noreferrer"
-								class="twitter with-icon"
-								>
-									<svg
-										class="icon"
-										fill="white"
-										viewBox="0 0 24 24"
-										xmlns="http://www.w3.org/2000/svg"
-										><path
-											d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"
-										/>
-									</svg>
-									Twitter
-								</a>
-							{/if}
-						</address>
-					{/each}
-					<h3>{title}</h3>
-				</div>
-				<div class="text">
-					{@html text}
-				</div>
+			<li>
+				<article class="speaker">
+					<div class="profile">
+						{#each author as {image}}
+							<img src={image} alt="" />
+						{/each}
+					</div>
+					<div class="title">
+						{#each author as speaker}
+							<address rel="author">{speaker.name}
+								{#if speaker.twitter}
+									<a
+									href="https://twitter.com/{speaker.twitter}"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="twitter with-icon"
+									aria-label="{speaker.name} Twitter"
+									>
+										<svg
+											class="icon"
+											fill="white"
+											viewBox="0 0 24 24"
+											xmlns="http://www.w3.org/2000/svg"
+											><path
+												d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"
+											/>
+										</svg>
+										Twitter
+									</a>
+								{/if}
+							</address>
+						{/each}
+						<h3>{title}</h3>
+					</div>
+					<div class="text">
+						{@html text}
+					</div>
+				</article>
 			</li>
 		{/each}
 	</ul>


### PR DESCRIPTION
Axe DevTools had a few warnings on the landing page. This PR resolves those.

- Links with the same name must have a similar purpose -- all the speaker Twitter links had the same name. I added an aria-label to include the speaker in the name read out to assistive tech, e.g. "Rich Harris Twitter"
- ARIA role should be appropriate for the element -- `<li>` can't have a role of article. Instead, I created an `<article>` element inside the list item.

The remaining warnings are only flagged for review and are not actually issues.